### PR TITLE
Fixed an Issue Regarding PHP Version Requirements In The Installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -103,15 +103,15 @@ version_msg="Unknown Raspbian Version"
 if [ "$rasp_version" -eq "11" ]; then
 	version_msg="Raspbian 11.0 (Bullseye)"
 	php_version="7.3"
-	php_package="php${php_version} php${php_version}-cgi php${php_version}-common php${php_version}-cli php${php_version}-fpm php${php_version}-mbstring php${php_version}-mysql php${php_version}-opcache php${php_version}-curl php${php_version}-gd php${php_version}-curl php${php_version}-zip php${php_version}-xml php-redis php${php_version}-dev"
+	php_package="php${php_version} php${php_version}-cgi php${php_version}-common php${php_version}-cli php${php_version}-fpm php${php_version}-mbstring php${php_version}-mysql php${php_version}-opcache php${php_version}-curl php${php_version}-gd php${php_version}-curl php${php_version}-zip php${php_version}-xml php${php_version}-redis php${php_version}-dev"
 elif [ "$rasp_version" -eq "10" ]; then
 	version_msg="Raspbian 10.0 (Buster)"
 	php_version="7.3"
-	php_package="php${php_version} php${php_version}-cgi php${php_version}-common php${php_version}-cli php${php_version}-fpm php${php_version}-mbstring php${php_version}-mysql php${php_version}-opcache php${php_version}-curl php${php_version}-gd php${php_version}-curl php${php_version}-zip php${php_version}-xml php-redis php${php_version}-dev"
+	php_package="php${php_version} php${php_version}-cgi php${php_version}-common php${php_version}-cli php${php_version}-fpm php${php_version}-mbstring php${php_version}-mysql php${php_version}-opcache php${php_version}-curl php${php_version}-gd php${php_version}-curl php${php_version}-zip php${php_version}-xml php${php_version}-redis php${php_version}-dev"
 elif [ "$rasp_version" -eq "9" ]; then
 	version_msg="Raspbian 9.0 (Stretch)"
 	php_version="7.3"
-	php_package="php${php_version} php${php_version}-cgi php${php_version}-common php${php_version}-cli php${php_version}-fpm php${php_version}-mbstring php${php_version}-mysql php${php_version}-opcache php${php_version}-curl php${php_version}-gd php${php_version}-curl php${php_version}-zip php${php_version}-xml php-redis php${php_version}-dev"
+	php_package="php${php_version} php${php_version}-cgi php${php_version}-common php${php_version}-cli php${php_version}-fpm php${php_version}-mbstring php${php_version}-mysql php${php_version}-opcache php${php_version}-curl php${php_version}-gd php${php_version}-curl php${php_version}-zip php${php_version}-xml php${php_version}-redis php${php_version}-dev"
 elif [ "$rasp_version" -lt "9" ]; then
 	echo "Raspbian ${rasp_version} is unsupported. Please upgrade."
 	exit 1

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -10,7 +10,7 @@ version_msg="Unknown Raspbian Version"
 if [ "$rasp_version" -eq "11" ]; then
 	version_msg="Raspbian 11.0 (Bullseye)"
 	php_package="php7.3-cgi"
-if [ "$rasp_version" -eq "10" ]; then
+elif [ "$rasp_version" -eq "10" ]; then
 	version_msg="Raspbian 10.0 (Buster)"
 	php_package="php7.3-cgi"
 elif [ "$rasp_version" -eq "9" ]; then

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,6 +7,9 @@ user=$(whoami)
 
 # Determine Raspbian version
 version_msg="Unknown Raspbian Version"
+if [ "$rasp_version" -eq "11" ]; then
+	version_msg="Raspbian 11.0 (Bullseye)"
+	php_package="php7.3-cgi"
 if [ "$rasp_version" -eq "10" ]; then
 	version_msg="Raspbian 10.0 (Buster)"
 	php_package="php7.3-cgi"


### PR DESCRIPTION
It seems that one of the PHP packages didn't specify a version in the install script. I updated this to follow the same version of PHP that the other PHP dependencies are being installed with.

Also noticed that there wasn't any handling for Rasbian 11 in the uninstall script. I updated this as well since this is the version I am using.

Tested this by running an install using a local copy of the install script on a Desktop running Rasbian 11 using the force-yes option and the install succeeded without intervention. Also ran the uninstall script and observed the environment being detected and the defined PHP package being removed.